### PR TITLE
Support multiple helm chart expansions from same values file

### DIFF
--- a/pkg/cluster/kube/ordered_client.go
+++ b/pkg/cluster/kube/ordered_client.go
@@ -17,6 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// TODO: Switch to a YAML library that supports doing this splitting for us.
 var sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
 
 // OrderedClient is a kubectl-wrapped client that tries to be clever about the order

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	// TODO: Switch to a YAML library that supports doing this splitting for us.
 	sep = regexp.MustCompile("(?:^|\\s*\n)---\\s*")
 
 	// Header comments that can be set in helm chart values files to change default behavior

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -68,11 +68,32 @@ func TestExpandHelmTemplates(t *testing.T) {
 				"kube-system/alb-ingress-controller.helm.yaml",
 			},
 			expContents: map[string][]string{
-				"kube-system/alb-ingress-controller/templates/alb-ingress-controller.yaml": {
+				"kube-system/name-override/alb-ingress-controller/templates/alb-ingress-controller.yaml": {
 					"name: alb-ingress-controller-name-override",
 					"namespace: kube-system",
 					"image: test-image2",
 					"helm/test: override",
+				},
+			},
+		},
+		{
+			description: "chart multi",
+			configPath:  "testdata/configs-charts-multi",
+			expDoesNotExist: []string{
+				"kube-system/alb-ingress-controller.helm.yaml",
+			},
+			expContents: map[string][]string{
+				"kube-system/namespace1/alb-ingress-controller/templates/alb-ingress-controller.yaml": {
+					"name: alb-ingress-controller-namespace1",
+					"namespace: namespace1",
+					"image: test-image1",
+					"helm/test: normal",
+				},
+				"kube-system/namespace2/alb-ingress-controller/templates/alb-ingress-controller.yaml": {
+					"name: alb-ingress-controller-namespace2",
+					"namespace: namespace2",
+					"image: test-image2",
+					"helm/test: normal",
 				},
 			},
 		},

--- a/pkg/helm/testdata/configs-charts-multi/kube-system/alb-ingress-controller.helm.yaml
+++ b/pkg/helm/testdata/configs-charts-multi/kube-system/alb-ingress-controller.helm.yaml
@@ -1,0 +1,10 @@
+---
+# kubeapply__namespace: namespace1
+# kubeapply__releaseName: namespace1
+image: "test-image1"
+---
+# kubeapply__namespace: namespace2
+# kubeapply__releaseName: namespace2
+
+image: "test-image2"
+


### PR DESCRIPTION
## Description
This change updates the `kubeapply` helm behavior to support multiple expansions from a multi-part values file, i.e. with the parts separated by `---` lines. This can be used to generate multiple releases from the same chart, among other use cases. See the included unit test for an example.

This change also cleans up some of the chart headers parsing logic to make the supported header names a little more clear.