### PR TITLE
Add support for chart versions

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -22,6 +22,7 @@ var (
 	// Header comments that can be set in helm chart values files to change default behavior
 	chartOverrideHeaders     = []string{"kubeapply__chart", "kubeapply__charts", "charts"}
 	chartNameHeaders         = []string{"kubeapply__chartName", "chartName"}
+	chartVersionHeaders      = []string{"kubeapply__chartVersion", "chartVersion"}
 	chartsSubDirHeaders      = []string{"kubeapply__chartsSubdir"}
 	disabledHeaders          = []string{"kubeapply__disabled", "disabled"}
 	namespaceOverrideHeaders = []string{"kubeapply__namespace", "namespace"}
@@ -252,6 +253,11 @@ func (c *HelmClient) generateHelmTemplates(
 		chartNamePath = chartNameOverride
 	} else {
 		chartNamePath = nameComponents[0]
+	}
+
+	chartVersion := getValue(headerComments, chartVersionHeaders...)
+	if chartVersion != "" {
+		chartNamePath = filepath.Join(chartNamePath, chartVersion)
 	}
 
 	namespaceOverride := getValue(headerComments, namespaceOverrideHeaders...)

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -98,6 +98,21 @@ func TestExpandHelmTemplates(t *testing.T) {
 			},
 		},
 		{
+			description: "chart version",
+			configPath:  "testdata/configs-versioned",
+			expDoesNotExist: []string{
+				"kube-system/alb-ingress-controller.helm.yaml",
+			},
+			expContents: map[string][]string{
+				"kube-system/alb-ingress-controller/templates/alb-ingress-controller.yaml": {
+					"name: alb-ingress-controller-RELEASE-NAME-v2",
+					"namespace: kube-system",
+					"image: test-image2",
+					"helm/test: normal",
+				},
+			},
+		},
+		{
 			description: "chart disabled",
 			configPath:  "testdata/configs-disabled",
 			expDoesNotExist: []string{
@@ -158,7 +173,7 @@ func TestExpandHelmTemplates(t *testing.T) {
 				exists, err := util.FileExists(fullPath)
 
 				require.Nil(t, err, testCase.description)
-				require.True(t, exists, testCase.description)
+				require.True(t, exists, fullPath, testCase.description)
 
 				contents, err := ioutil.ReadFile(fullPath)
 				require.Nil(t, err, testCase.description)

--- a/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v1/Chart.yaml
+++ b/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v1/Chart.yaml
@@ -1,0 +1,7 @@
+name: alb-ingress-controller
+description: Helm Chart for alb-ingress-controller
+engine: gotpl
+maintainers:
+- email: team-sre@segment.com
+  name: SRE
+version: 0.1.1

--- a/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v1/templates/alb-ingress-controller.yaml
+++ b/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v1/templates/alb-ingress-controller.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: alb-ingress-controller
+  name: alb-ingress-controller-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alb-ingress-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: alb-ingress-controller
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "10254"
+        helm/test: normal
+    spec:
+      containers:
+        - args:
+            - --ingress-class=alb
+            - --cluster-name=my-cluster
+            - --aws-region=us-west-2
+            - --aws-max-retries=10
+            - --target-type=ip
+          {{- if .Values.vpcId }}
+            - --aws-vpc-id={{ .Values.vpcId }}
+          {{- end }}
+          env:
+          image: {{ .Values.image }}
+          imagePullPolicy: Always
+          name: alb-ingress-controller
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      serviceAccountName: alb-ingress
+      serviceAccount: alb-ingress
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v1/templates/rbac-role.yaml
+++ b/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v1/templates/rbac-role.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: alb-ingress-controller
+  name: alb-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - ingresses
+      - ingresses/status
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - nodes
+      - pods
+      - secrets
+      - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: alb-ingress-controller
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: alb-ingress
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: alb-ingress-controller
+  name: alb-ingress
+  namespace: {{ .Release.Namespace }}

--- a/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v1/values.yaml
+++ b/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v1/values.yaml
@@ -1,0 +1,11 @@
+# Name of the cluster
+cluster: ""
+
+# Docker image for the ALB Ingess Controller
+image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
+
+# Enforce which worker pool the controller will be deployed on
+nodeSelector: {}
+
+# Priority class for the Kubernetes scheduler
+priorityClassName: "cluster-critical"

--- a/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v2/Chart.yaml
+++ b/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v2/Chart.yaml
@@ -1,0 +1,7 @@
+name: alb-ingress-controller
+description: Helm Chart for alb-ingress-controller
+engine: gotpl
+maintainers:
+- email: team-sre@segment.com
+  name: SRE
+version: 0.1.1

--- a/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v2/templates/alb-ingress-controller.yaml
+++ b/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v2/templates/alb-ingress-controller.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: alb-ingress-controller
+  name: alb-ingress-controller-{{ .Release.Name }}-v2
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alb-ingress-controller
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: alb-ingress-controller
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "10254"
+        helm/test: normal
+    spec:
+      containers:
+        - args:
+            - --ingress-class=alb
+            - --cluster-name=my-cluster
+            - --aws-region=us-west-2
+            - --aws-max-retries=10
+            - --target-type=ip
+          {{- if .Values.vpcId }}
+            - --aws-vpc-id={{ .Values.vpcId }}
+          {{- end }}
+          env:
+          image: {{ .Values.image }}
+          imagePullPolicy: Always
+          name: alb-ingress-controller
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      serviceAccountName: alb-ingress
+      serviceAccount: alb-ingress
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v2/templates/rbac-role.yaml
+++ b/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v2/templates/rbac-role.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: alb-ingress-controller
+  name: alb-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - ingresses
+      - ingresses/status
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - nodes
+      - pods
+      - secrets
+      - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: alb-ingress-controller
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: alb-ingress
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: alb-ingress-controller
+  name: alb-ingress
+  namespace: {{ .Release.Namespace }}

--- a/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v2/values.yaml
+++ b/pkg/helm/testdata/charts-versioned/alb-ingress-controller/v2/values.yaml
@@ -1,0 +1,11 @@
+# Name of the cluster
+cluster: ""
+
+# Docker image for the ALB Ingess Controller
+image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
+
+# Enforce which worker pool the controller will be deployed on
+nodeSelector: {}
+
+# Priority class for the Kubernetes scheduler
+priorityClassName: "cluster-critical"

--- a/pkg/helm/testdata/configs-versioned/kube-system/alb-ingress-controller.helm.yaml
+++ b/pkg/helm/testdata/configs-versioned/kube-system/alb-ingress-controller.helm.yaml
@@ -1,0 +1,4 @@
+# kubeapply__charts: file://testdata/charts-versioned
+# kubeapply__chartVersion: v2
+
+image: "test-image2"


### PR DESCRIPTION
## Description
This change updates the kubeapply helm chart expansion logic to support optional version subdirectories in the source charts. We're planning on using these at Segment to make chart version management easier.
