### PR TITLE
Increase webhook handler diff and apply timeouts

### DIFF
--- a/pkg/events/handler.go
+++ b/pkg/events/handler.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	applyTimeout = 60 * time.Second
-	diffTimeout  = 120 * time.Second
+	applyTimeout = 600 * time.Second
+	diffTimeout  = 600 * time.Second
 )
 
 // WebhookHandler is a struct that handles incoming Github webhooks. Depending on the webhook


### PR DESCRIPTION
## Description
This change increases the diff and apply timeouts in the kubeapply webhook flow to 10 minutes. The current limits are too low for some large clusters that we're running at Segment.