### PR TITLE
Fix ECR publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   publish:
     working_directory: /go/src/github.com/segmentio/kubeapply
     docker:
-      - image: circleci/python:3.7.9
+      - image: circleci/golang:1.14
 
     steps:
       - checkout
@@ -49,7 +49,8 @@ jobs:
       - run:
           name: ECR Login
           command: |
-            pip install awscli==1.16.292
+            sudo apt-get update && sudo apt-get install --yes python3 python3-pip
+            pip3 install awscli==1.16.292
             $(aws ecr get-login --no-include-email --region ${AWS_REGION} --registry-ids ${AWS_ACCOUNT_ID})
       - run:
           name: Build and push image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   publish:
     working_directory: /go/src/github.com/segmentio/kubeapply
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/python:3.7.9
 
     steps:
       - checkout
@@ -49,7 +49,6 @@ jobs:
       - run:
           name: ECR Login
           command: |
-            curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
             pip install awscli==1.16.292
             $(aws ecr get-login --no-include-email --region ${AWS_REGION} --registry-ids ${AWS_ACCOUNT_ID})
       - run:


### PR DESCRIPTION
## Description
This change fixes the ECR publishing step in the CI. `pip` stopped supporting Python2 (what's in the go images by default), so the AWS CLI installation stopped working.