### PR TITLE
Misc. fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ environments. We welcome feedback and collaboration to make `kubeapply` useful t
 
 `kubeapply` depends on the following tools:
 
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): v1.13 or newer
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): v1.16 or newer
 - [`helm`](https://helm.sh/docs/intro/install/): v3.5.0 or newer (only needed if using helm charts)
-- [`kubeval`](https://kubeval.instrumenta.dev/installation/): v1.13 or newer
+- [`kubeval`](https://kubeval.instrumenta.dev/installation/): v0.15.0 or newer
 
 Make sure that they're installed locally and available in your path.
 

--- a/cmd/kubeapply/subcmd/apply.go
+++ b/cmd/kubeapply/subcmd/apply.go
@@ -175,7 +175,7 @@ func applyClusterPath(ctx context.Context, path string) error {
 			return err
 		}
 
-		results, rawDiffs, err := execDiff(ctx, clusterConfig, !applyFlagValues.simpleOutput)
+		results, rawDiffs, err := execDiff(ctx, clusterConfig, applyFlagValues.simpleOutput)
 		if err != nil {
 			log.Errorf("Error running diff: %+v", err)
 			log.Info(
@@ -185,7 +185,7 @@ func applyClusterPath(ctx context.Context, path string) error {
 		}
 
 		if results != nil {
-			diff.PrintSummary(results)
+			diff.PrintFull(results)
 		} else {
 			log.Infof("Raw diff results:\n%s", rawDiffs)
 		}

--- a/cmd/kubeapply/subcmd/diff_test.go
+++ b/cmd/kubeapply/subcmd/diff_test.go
@@ -25,6 +25,4 @@ func TestDiff(t *testing.T) {
 		filepath.Join(testClusterDir, "cluster.yaml"),
 	)
 	require.Nil(t, err)
-
-	// TODO: Make this test more sophisticated.
 }

--- a/cmd/kubeapply/subcmd/expand.go
+++ b/cmd/kubeapply/subcmd/expand.go
@@ -34,27 +34,27 @@ var expandCmd = &cobra.Command{
 }
 
 type expandFlags struct {
-	// Number of helm instances to run in parallel when expanding out charts.
-	helmParallelism int
-
 	// Clean old configs in expanded directory before expanding
 	clean bool
+
+	// Number of helm instances to run in parallel when expanding out charts.
+	helmParallelism int
 }
 
 var expandFlagsValues expandFlags
 
 func init() {
-	expandCmd.Flags().IntVar(
-		&expandFlagsValues.helmParallelism,
-		"parallelism",
-		5,
-		"Parallelism on helm expansions",
-	)
 	expandCmd.Flags().BoolVar(
 		&expandFlagsValues.clean,
 		"clean",
 		false,
 		"Clean out old configs in expanded directory",
+	)
+	expandCmd.Flags().IntVar(
+		&expandFlagsValues.helmParallelism,
+		"helm-parallelism",
+		5,
+		"Parallelism on helm expansions",
 	)
 
 	RootCmd.AddCommand(expandCmd)

--- a/cmd/kubeapply/subcmd/expand.go
+++ b/cmd/kubeapply/subcmd/expand.go
@@ -211,6 +211,7 @@ func expandProfile(
 		expandedPath,
 		clusterConfig,
 		true,
+		true,
 	)
 	if err != nil {
 		return err

--- a/data/data.go
+++ b/data/data.go
@@ -13,6 +13,7 @@
 // scripts/kdiff-wrapper.sh
 // scripts/kindctl.sh
 // scripts/pull-deps.sh
+// scripts/raw-diff.sh
 package data
 
 import (
@@ -329,6 +330,26 @@ func scriptsPullDepsSh() (*asset, error) {
 	return a, nil
 }
 
+var _scriptsRawDiffSh = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x24\xcc\x31\x8a\xc3\x30\x10\x40\xd1\x7e\x4e\xf1\x17\xbb\x15\xc6\xdb\x6e\xb1\x55\xda\x5c\xc0\xb8\x90\xc9\x28\x12\x18\x09\x46\x63\x9c\xe4\xf4\x21\xa4\x7f\xbc\xe1\x67\xda\x4a\x9d\xb6\xd8\xb3\xc8\xad\xa4\x44\x38\x08\x57\xc6\x99\xf1\x57\x64\xe0\x52\xfb\x61\x8a\xe7\xe8\x9c\x4a\xab\xfb\x13\x7d\x14\xe7\x2c\x9e\xa9\xad\x86\x97\x5a\xa3\x7b\xf4\xa3\x53\x3a\x9e\xd5\x94\x33\x76\x22\xa6\x71\x47\xcd\x9a\x49\x49\x2c\x0b\xe3\x3f\xe1\xee\xcc\xac\xeb\xdf\x47\x56\x01\xbe\xdf\x2c\xa9\xc8\x3b\x00\x00\xff\xff\x66\x89\xc3\x1f\x8f\x00\x00\x00")
+
+func scriptsRawDiffShBytes() ([]byte, error) {
+	return bindataRead(
+		_scriptsRawDiffSh,
+		"scripts/raw-diff.sh",
+	)
+}
+
+func scriptsRawDiffSh() (*asset, error) {
+	bytes, err := scriptsRawDiffShBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "scripts/raw-diff.sh", size: 143, mode: os.FileMode(420), modTime: time.Unix(1612469663, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -393,6 +414,7 @@ var _bindata = map[string]func() (*asset, error){
 	"scripts/kdiff-wrapper.sh":                   scriptsKdiffWrapperSh,
 	"scripts/kindctl.sh":                         scriptsKindctlSh,
 	"scripts/pull-deps.sh":                       scriptsPullDepsSh,
+	"scripts/raw-diff.sh":                        scriptsRawDiffSh,
 }
 
 // AssetDir returns the file names below a certain
@@ -457,6 +479,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"kdiff-wrapper.sh":        &bintree{scriptsKdiffWrapperSh, map[string]*bintree{}},
 		"kindctl.sh":              &bintree{scriptsKindctlSh, map[string]*bintree{}},
 		"pull-deps.sh":            &bintree{scriptsPullDepsSh, map[string]*bintree{}},
+		"raw-diff.sh":             &bintree{scriptsRawDiffSh, map[string]*bintree{}},
 	}},
 }}
 

--- a/pkg/cluster/kube/ordered_client.go
+++ b/pkg/cluster/kube/ordered_client.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	diffScript = "kdiff-wrapper.sh"
+	structuredDiffScript = "kdiff-wrapper.sh"
+	rawDiffScript        = "raw-diff.sh"
 )
 
 // TODO: Switch to a YAML library that supports doing this splitting for us.
@@ -183,23 +184,28 @@ func (k *OrderedClient) Diff(
 	}
 
 	envVars := []string{}
+	var diffScript string
 
 	if structured {
-		diffCmd = filepath.Join(tempDir, diffScript)
-		err = ioutil.WriteFile(
-			diffCmd,
-			data.MustAsset(fmt.Sprintf("scripts/%s", diffScript)),
-			0755,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		envVars = append(
-			envVars,
-			fmt.Sprintf("KUBECTL_EXTERNAL_DIFF=%s", diffCmd),
-		)
+		diffScript = structuredDiffScript
+	} else {
+		diffScript = rawDiffScript
 	}
+
+	diffCmd = filepath.Join(tempDir, diffScript)
+	err = ioutil.WriteFile(
+		diffCmd,
+		data.MustAsset(fmt.Sprintf("scripts/%s", diffScript)),
+		0755,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	envVars = append(
+		envVars,
+		fmt.Sprintf("KUBECTL_EXTERNAL_DIFF=%s", diffCmd),
+	)
 
 	return runKubectlOutput(
 		ctx,

--- a/pkg/cluster/kube_client.go
+++ b/pkg/cluster/kube_client.go
@@ -266,7 +266,10 @@ func (cc *KubeClusterClient) Config() *config.ClusterConfig {
 }
 
 // GetNamespaceUID returns the kubernetes identifier for a given namespace in this cluster.
-func (cc *KubeClusterClient) GetNamespaceUID(ctx context.Context, namespace string) (string, error) {
+func (cc *KubeClusterClient) GetNamespaceUID(
+	ctx context.Context,
+	namespace string,
+) (string, error) {
 	return cc.kubeClient.GetNamespaceUID(ctx, namespace)
 }
 

--- a/pkg/events/handler.go
+++ b/pkg/events/handler.go
@@ -422,7 +422,11 @@ func (whh *WebhookHandler) runApply(
 				clusterClient.Config().ServerSideApply,
 			)
 			if err != nil {
-				applyErr = fmt.Errorf("%+v", err)
+				applyErr = fmt.Errorf(
+					"Error applying for cluster %s: %+v",
+					clusterName,
+					err,
+				)
 				break
 			}
 
@@ -553,7 +557,11 @@ func (whh *WebhookHandler) runDiffs(
 			clusterClient.Config().ServerSideApply,
 		)
 		if err != nil {
-			diffErr = fmt.Errorf("%+v", err)
+			diffErr = fmt.Errorf(
+				"Error diffing for cluster %s: %+v",
+				clusterName,
+				err,
+			)
 			break
 		}
 

--- a/pkg/events/handler_test.go
+++ b/pkg/events/handler_test.go
@@ -338,7 +338,7 @@ func TestHandleWebhook(t *testing.T) {
 			expComments: []commentMatch{
 				{
 					contains: []string{
-						"Error comment: kubectl error",
+						"Error comment: Error diffing for cluster test-env:test-region:test-cluster2: kubectl error",
 					},
 				},
 			},
@@ -581,7 +581,7 @@ func TestHandleWebhook(t *testing.T) {
 			expComments: []commentMatch{
 				{
 					contains: []string{
-						"Error comment: kubectl error",
+						"Error comment: Error applying for cluster test-env:test-region:test-cluster2: kubectl error",
 					},
 				},
 			},

--- a/pkg/pullreq/diffs.go
+++ b/pkg/pullreq/diffs.go
@@ -52,6 +52,9 @@ func GetCoveredClusters(
 	err := filepath.Walk(
 		repoRoot,
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			if info.IsDir() {
 				return nil
 			}
@@ -212,6 +215,9 @@ func getExpandedConfigFiles(
 	err := filepath.Walk(
 		configObj.ExpandedPath,
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			if info.IsDir() {
 				return nil
 			}

--- a/pkg/star/expand/expand.go
+++ b/pkg/star/expand/expand.go
@@ -40,6 +40,9 @@ func ExpandStar(
 	err := filepath.Walk(
 		expandRoot,
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			if info.IsDir() {
 				return nil
 			}

--- a/pkg/util/paths.go
+++ b/pkg/util/paths.go
@@ -115,6 +115,9 @@ func RemoveDirs(rootDir string, indicatorName string) error {
 	err := filepath.Walk(
 		rootDir,
 		func(subPath string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
 			if !info.IsDir() && strings.ToLower(filepath.Base(subPath)) == indicatorName {
 				dirsToRemove = append(dirsToRemove, filepath.Dir(subPath))
 			}

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -49,7 +49,8 @@ func ApplyTemplate(
 
 			err = applyTemplateFile(subPath, data, true, strict, outFile)
 			if err != nil {
-				return err
+				// Wrap the error so that we can provide more context
+				return fmt.Errorf("Error expanding path %s: %+v", subPath, err)
 			}
 
 			if deleteSources {

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -22,7 +22,12 @@ var extraTemplateFuncs = template.FuncMap{
 
 // ApplyTemplate runs golang templating on all files in the provided path,
 // replacing them in-place with their templated versions.
-func ApplyTemplate(dir string, data interface{}, deleteSources bool) error {
+func ApplyTemplate(
+	dir string,
+	data interface{},
+	deleteSources bool,
+	strict bool,
+) error {
 	return filepath.Walk(
 		dir,
 		func(subPath string, info os.FileInfo, err error) error {
@@ -42,7 +47,7 @@ func ApplyTemplate(dir string, data interface{}, deleteSources bool) error {
 			}
 			defer outFile.Close()
 
-			err = applyTemplateFile(subPath, data, true, outFile)
+			err = applyTemplateFile(subPath, data, true, strict, outFile)
 			if err != nil {
 				return err
 			}
@@ -63,6 +68,7 @@ func applyTemplateFile(
 	path string,
 	data interface{},
 	allowContents bool,
+	strict bool,
 	out io.Writer,
 ) error {
 	templateFuncs := sprig.TxtFuncMap()
@@ -72,14 +78,18 @@ func applyTemplateFile(
 	}
 
 	if allowContents {
-		templateFuncs["fileContents"] = fileContentsGenerator(path, data)
-		templateFuncs["configMapEntry"] = configMapEntryGenerator(path, data)
-		templateFuncs["configMapEntries"] = configMapEntriesGenerator(path, data)
+		templateFuncs["fileContents"] = fileContentsGenerator(path, data, strict)
+		templateFuncs["configMapEntry"] = configMapEntryGenerator(path, data, strict)
+		templateFuncs["configMapEntries"] = configMapEntriesGenerator(path, data, strict)
 	}
 
-	tmpl, err := template.New(filepath.Base(path)).
-		Funcs(templateFuncs).
-		ParseFiles(path)
+	tmpl := template.New(filepath.Base(path)).Funcs(templateFuncs)
+	if strict {
+		tmpl = tmpl.Option("missingkey=error")
+	}
+
+	var err error
+	tmpl, err = tmpl.ParseFiles(path)
 	if err != nil {
 		return err
 	}
@@ -90,6 +100,7 @@ func applyTemplateFile(
 func fileContentsGenerator(
 	templatePath string,
 	data interface{},
+	strict bool,
 ) func(string) (string, error) {
 	return func(relPath string) (string, error) {
 		configPath := filepath.Join(
@@ -97,7 +108,7 @@ func fileContentsGenerator(
 			relPath,
 		)
 		buf := &bytes.Buffer{}
-		err := applyTemplateFile(configPath, data, false, buf)
+		err := applyTemplateFile(configPath, data, false, strict, buf)
 		if err != nil {
 			return "", err
 		}
@@ -109,6 +120,7 @@ func fileContentsGenerator(
 func configMapEntryGenerator(
 	templatePath string,
 	data interface{},
+	strict bool,
 ) func(string) (string, error) {
 	return func(relPath string) (string, error) {
 		configPath := filepath.Join(
@@ -116,7 +128,7 @@ func configMapEntryGenerator(
 			relPath,
 		)
 		buf := &bytes.Buffer{}
-		err := applyTemplateFile(configPath, data, false, buf)
+		err := applyTemplateFile(configPath, data, false, strict, buf)
 		if err != nil {
 			return "", err
 		}
@@ -144,6 +156,7 @@ func configMapEntryGenerator(
 func configMapEntriesGenerator(
 	templatePath string,
 	data interface{},
+	strict bool,
 ) func(string) (string, error) {
 	return func(relPath string) (string, error) {
 		outputLines := []string{}
@@ -171,7 +184,7 @@ func configMapEntriesGenerator(
 				dirFile.Name(),
 			)
 			buf := &bytes.Buffer{}
-			err := applyTemplateFile(configPath, data, false, buf)
+			err := applyTemplateFile(configPath, data, false, strict, buf)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -34,7 +34,6 @@ func ApplyTemplate(
 			if err != nil {
 				return err
 			}
-
 			if info.IsDir() || !strings.Contains(subPath, ".gotpl.") {
 				return nil
 			}

--- a/pkg/util/template_test.go
+++ b/pkg/util/template_test.go
@@ -112,7 +112,6 @@ func getAllFiles(t *testing.T, path string) []string {
 			if err != nil {
 				return err
 			}
-
 			if info.IsDir() {
 				return nil
 			}

--- a/pkg/util/template_test.go
+++ b/pkg/util/template_test.go
@@ -26,6 +26,7 @@ func TestApplyTemplate(t *testing.T) {
 			"value2": "value2Data",
 		},
 		true,
+		false,
 	)
 	require.Nil(t, err)
 
@@ -81,6 +82,25 @@ configMap2:
 			fileContents(t, filepath.Join(tempDir, "test2.yaml")),
 		),
 	)
+}
+
+func TestApplyTemplateStrict(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "templates")
+	require.Nil(t, err)
+	defer os.RemoveAll(tempDir)
+
+	err = RecursiveCopy("testdata/templates", tempDir)
+	require.Nil(t, err)
+
+	err = ApplyTemplate(
+		tempDir,
+		map[string]string{
+			"value1": "value1Data",
+		},
+		true,
+		true,
+	)
+	require.Error(t, err)
 }
 
 func getAllFiles(t *testing.T, path string) []string {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version stores the current kubeapply version.
-const Version = "0.0.24"
+const Version = "0.0.25"

--- a/scripts/raw-diff.sh
+++ b/scripts/raw-diff.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+diff -u -N $1 $2
+
+# Ensure that we only exit with non-zero status is there was a real error
+if [[ $? -gt 1 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Description
This change includes a number of fixes and improvements based on user feedback:

1. Throw an error during expansion if template uses a parameter that's not defined in the associated cluster config
2. Check for errors when walking directory paths; otherwise, if the path doesn't exist, this can cause a panic
3. Include more context in diff and apply errors generated during webhook runs
4. Fix bug in how `--simple-output` flag is handled in apply
5. Improve processing of errors when running an unstructured diff