### PR TITLE
Make webhooks apply rules more fine-grained

### DIFF
--- a/cmd/kubeapply-server/main.go
+++ b/cmd/kubeapply-server/main.go
@@ -41,8 +41,12 @@ type Config struct {
 	Env           string `conf:"env"            help:"only consider changes for this environment"`
 	GithubToken   string `conf:"github-token"   help:"token for Github API access"`
 	LogsURL       string `conf:"logs-url"       help:"url for logs; used as link for status checks"`
-	StrictCheck   bool   `conf:"strict-check"   help:"ensure green status and approval before apply"`
 	WebhookSecret string `conf:"webhook-secret" help:"shared secret set in Github webhooks"`
+
+	// TODO: Deprecate StrictCheck since it's covered by the parameters below that.
+	StrictCheck     bool `conf:"strict-check"      help:"ensure green status and approval before apply"`
+	GreenCIRequired bool `conf:"green-ci-required" help:"require green CI before applying"`
+	ReviewRequired  bool `conf:"review-required"   help:"require review before applying:"`
 }
 
 var config = Config{
@@ -121,6 +125,8 @@ func webhookHTTPHandler(
 			ApplyConsistencyCheck: false,
 			Automerge:             config.Automerge,
 			StrictCheck:           config.StrictCheck,
+			GreenCIRequired:       config.GreenCIRequired,
+			ReviewRequired:        config.ReviewRequired,
 			Debug:                 config.Debug,
 		},
 	)

--- a/cmd/kubeapply/subcmd/pull_request.go
+++ b/cmd/kubeapply/subcmd/pull_request.go
@@ -56,8 +56,16 @@ type pullRequestFlags struct {
 	// Full name of the repo, in [owner]/[name] format
 	repo string
 
-	// Whether to be strict about checking for approvals and green github status
+	// Whether to be strict about checking for approvals and green github status.
+	//
+	// Deprecated, to be replaced by the values below.
 	strictCheck bool
+
+	// Whether green CI is required to apply
+	greenCIRequired bool
+
+	// Whether a review is required to apply
+	reviewRequired bool
 }
 
 var pullRequestFlagValues pullRequestFlags
@@ -111,6 +119,12 @@ func init() {
 		"",
 		"Installation ID for github app",
 	)
+	pullRequestCmd.Flags().BoolVar(
+		&pullRequestFlagValues.greenCIRequired,
+		"green-ci-required",
+		false,
+		"Whether a green CI is required to apply",
+	)
 	pullRequestCmd.Flags().IntVar(
 		&pullRequestFlagValues.pullRequestNum,
 		"pull-request",
@@ -122,6 +136,12 @@ func init() {
 		"repo",
 		"",
 		"Repo to post comment in, in format [owner]/[name]",
+	)
+	pullRequestCmd.Flags().BoolVar(
+		&pullRequestFlagValues.reviewRequired,
+		"review-required",
+		false,
+		"Whether a review is required to apply",
 	)
 	pullRequestCmd.Flags().BoolVar(
 		&pullRequestFlagValues.strictCheck,
@@ -265,6 +285,8 @@ func pullRequestRun(cmd *cobra.Command, args []string) error {
 			ApplyConsistencyCheck: false,
 			Automerge:             pullRequestFlagValues.automerge,
 			StrictCheck:           pullRequestFlagValues.strictCheck,
+			GreenCIRequired:       pullRequestFlagValues.greenCIRequired,
+			ReviewRequired:        pullRequestFlagValues.reviewRequired,
 			Debug:                 debug,
 		},
 	)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,6 +76,12 @@ type ClusterConfig struct {
 	// Optional, defaults to false.
 	GithubIgnore bool `json:"ignore"`
 
+	// ReviewOptional indicates that reviews should not be required for changes in this
+	// cluster even if strict mode is on.
+	//
+	// Optional, and only applicable to webhooks mode.
+	GithubReviewOptional bool `json:"reviewOptional"`
+
 	// VersionConstraint is a string version constraint against with the kubeapply binary
 	// will be checked. See https://github.com/Masterminds/semver for details on the expected
 	// format.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version stores the current kubeapply version.
-const Version = "0.0.25"
+const Version = "0.0.26"


### PR DESCRIPTION
## Description
This change includes a few updates to the apply rules that are evaluated in the Github webhooks flow:

1. Split the current "strict check" parameter into two- one for requiring a green CI and the other for requiring a review approval; the old parameter will be fully deprecated in a later change
2. Add a `reviewOptional` parameter into cluster configs that allows one to override review approval checks for an individual cluster