### PR TITLE
Strip out kubectl warnings

### DIFF
--- a/pkg/cluster/kube_client.go
+++ b/pkg/cluster/kube_client.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -236,6 +237,13 @@ func (cc *KubeClusterClient) DiffStructured(
 			err,
 			string(rawResults),
 		)
+	}
+
+	// Strip everything before the initial "{"; kubectl can insert arbitrary warnings, etc.
+	// that can cause the result to not be valid JSON.
+	jsonStart := bytes.Index(rawResults, []byte("{"))
+	if jsonStart > 0 {
+		rawResults = rawResults[jsonStart:]
 	}
 
 	results := diff.Results{}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version stores the current kubeapply version.
-const Version = "0.0.26"
+const Version = "0.0.27"


### PR DESCRIPTION
## Description
This change updates the structured diff client to ignore warnings and other characters before the JSON output starts. We noticed these warnings after upgrading one of our clusters to v1.19.