### PR TITLE
Add lookup function

### DIFF
--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -226,6 +226,7 @@ func lookup(path string, input interface{}) interface{} {
 	obj := reflect.ValueOf(input)
 
 	components := strings.Split(path, ".")
+
 	for i := 0; i < len(components); {
 		component := components[i]
 
@@ -240,8 +241,8 @@ func lookup(path string, input interface{}) interface{} {
 			// Get the thing being pointed to or interfaced, don't advance index
 			obj = obj.Elem()
 		default:
-			obj = zeroValue
-			break
+			// Got an unexpected type
+			return nil
 		}
 	}
 

--- a/pkg/util/template_test.go
+++ b/pkg/util/template_test.go
@@ -169,6 +169,7 @@ func TestLookup(t *testing.T) {
 	assert.Equal(t, "value0", lookup("Key", s))
 	assert.Equal(t, nil, lookup("bad-key", s))
 	assert.Equal(t, nil, lookup("", s))
+	assert.Equal(t, nil, lookup("key", "not a map"))
 	assert.Equal(t, "value1", lookup("Inner.Map.key1", s))
 	assert.Equal(t, "value1", lookup("Inner.Map.key1", &s))
 	assert.Equal(t, "value4", lookup("Inner.Map.key2.key3.key4", s))

--- a/pkg/util/template_test.go
+++ b/pkg/util/template_test.go
@@ -136,3 +136,44 @@ func fileContents(t *testing.T, path string) string {
 
 	return string(contents)
 }
+
+type TestStruct struct {
+	Key    string
+	Inner  TestStructInner
+	Inner2 *TestStructInner
+}
+type TestStructInner struct {
+	Map map[string]interface{}
+}
+
+func TestLookup(t *testing.T) {
+	s := TestStruct{
+		Key: "value0",
+		Inner: TestStructInner{
+			Map: map[string]interface{}{
+				"key1": "value1",
+				"key2": map[string]interface{}{
+					"key3": map[string]interface{}{
+						"key4": "value4",
+					},
+					"key5": 1234,
+				},
+			},
+		},
+		Inner2: &TestStructInner{
+			Map: map[string]interface{}{
+				"key6": "value6",
+			},
+		},
+	}
+	assert.Equal(t, "value0", lookup("Key", s))
+	assert.Equal(t, nil, lookup("bad-key", s))
+	assert.Equal(t, nil, lookup("", s))
+	assert.Equal(t, "value1", lookup("Inner.Map.key1", s))
+	assert.Equal(t, "value1", lookup("Inner.Map.key1", &s))
+	assert.Equal(t, "value4", lookup("Inner.Map.key2.key3.key4", s))
+	assert.Equal(t, 1234, lookup("Inner.Map.key2.key5", s))
+	assert.Equal(t, nil, lookup("Inner.Map.non-existent-key", s))
+	assert.Equal(t, nil, lookup("Inner.Map.key2.non-existent-key", s))
+	assert.Equal(t, "value6", lookup("Inner2.Map.key6", s))
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version stores the current kubeapply version.
-const Version = "0.0.27"
+const Version = "0.0.28"


### PR DESCRIPTION
## Description
This change adds a new kubeapply template function, `lookup`, that can be used to look up a dot-delimited path in a map or struct. If the path exists, it returns the value, otherwise it returns `nil`. Adding this because the sprig `get` function doesn't support looking more than one level down.