### PR TITLE
Copy binaries to final container in single step.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,9 @@ RUN apt-get update && apt-get install --yes \
 
 RUN pip3 install awscli
 
-COPY --from=builder /usr/local/bin/helm /usr/local/bin
-COPY --from=builder /usr/local/bin/kubeval /usr/local/bin
-COPY --from=builder /usr/local/bin/kubectl /usr/local/bin
-COPY --from=builder /usr/local/bin/kubeapply /usr/local/bin
+COPY --from=builder \
+    /usr/local/bin/helm \
+    /usr/local/bin/kubeval \
+    /usr/local/bin/kubectl \
+    /usr/local/bin/kubeapply \
+    /usr/local/bin


### PR DESCRIPTION
This eliminates three intermediate layers, which is nice for rootless systems using the VFS storage driver.

Multiple `COPY` reference: https://docs.docker.com/engine/reference/builder/#copy