### PR TITLE
Fix dockerfile copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ COPY --from=builder \
     /usr/local/bin/kubeval \
     /usr/local/bin/kubectl \
     /usr/local/bin/kubeapply \
-    /usr/local/bin
+    /usr/local/bin/


### PR DESCRIPTION
## Description
This change fixes the Dockerfile `COPY` step modified in https://github.com/segmentio/kubeapply/pull/34 to add a trailing slash.