### PR TITLE
Prune clusters with no changes when using wildcards

### DIFF
--- a/pkg/pullreq/diffs.go
+++ b/pkg/pullreq/diffs.go
@@ -175,6 +175,26 @@ func GetCoveredClusters(
 		}
 	}
 
+	// In case where someone has used a wildcard, prune clusters that have no changes
+	// to avoid unexpected applies.
+	hasWildcards := false
+
+	for _, globStr := range selectedClusterGlobStrs {
+		if strings.Contains(globStr, "*") {
+			hasWildcards = true
+			break
+		}
+	}
+
+	if hasWildcards {
+		for cluster, paths := range changedClusterPaths {
+			if len(paths) == 0 {
+				log.Infof("Removing cluster %s because it has no changes", cluster)
+				delete(changedClusterPaths, cluster)
+			}
+		}
+	}
+
 	log.Infof("Changed cluster paths: %+v", changedClusterPaths)
 
 	changedClusters := []*config.ClusterConfig{}

--- a/pkg/pullreq/diffs_test.go
+++ b/pkg/pullreq/diffs_test.go
@@ -170,6 +170,8 @@ func TestGetCoveredClusters(t *testing.T) {
 			selectedClusterGlobStrs: []string{
 				"stage:*",
 			},
+			// Cluster 3 is pruned from selection list because it doesn't have any files in the
+			// git diff.
 			expectedClustersIDs: []string{
 				"stage:us-west-2:cluster1",
 			},

--- a/pkg/pullreq/diffs_test.go
+++ b/pkg/pullreq/diffs_test.go
@@ -143,6 +143,43 @@ func TestGetCoveredClusters(t *testing.T) {
 		{
 			diffs: []*github.CommitFile{
 				{
+					Filename: aws.String("clusters/clustertype/expanded/cluster1/subdir1/file3.yaml"),
+				},
+				{
+					Filename: aws.String("clusters/clustertype/expanded/cluster3/file1.yaml"),
+				},
+			},
+			selectedClusterGlobStrs: []string{
+				"stage:*",
+			},
+			expectedClustersIDs: []string{
+				"stage:us-west-2:cluster1",
+				"stage:us-west-2:cluster3",
+			},
+			expectedSubpaths: []string{
+				"subdir1",
+				".",
+			},
+		},
+		{
+			diffs: []*github.CommitFile{
+				{
+					Filename: aws.String("clusters/clustertype/expanded/cluster1/subdir1/file3.yaml"),
+				},
+			},
+			selectedClusterGlobStrs: []string{
+				"stage:*",
+			},
+			expectedClustersIDs: []string{
+				"stage:us-west-2:cluster1",
+			},
+			expectedSubpaths: []string{
+				"subdir1",
+			},
+		},
+		{
+			diffs: []*github.CommitFile{
+				{
 					Filename: aws.String("clusters/clustertype/expanded/cluster1/file1.yaml"),
 				},
 				{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version stores the current kubeapply version.
-const Version = "0.0.32"
+const Version = "0.0.33"


### PR DESCRIPTION
## Description
This change updates the cluster selection process when using globs with wildcards to prune out clusters with no changes. Otherwise, if a user comments with something like `kubeapply apply *`, this operation might get applied to clusters that weren't shown in the original diff.

## Testing
Testing completed successfully via some additional unit tests.