### PR TITLE
BGLRINFRA-1066: extensionsv1beta1 to extensionsv1 api deprecation change

### DIFF
--- a/pkg/star/convert/modules.go
+++ b/pkg/star/convert/modules.go
@@ -19,6 +19,7 @@ var modules = map[string]string{
 	"corev1":            "k8s.io/api/core/v1",
 	"eventsv1beta1":     "k8s.io/api/events/v1beta1",
 	"extensionsv1beta1": "k8s.io/api/extensions/v1beta1",
+	"extensionsv1":      "k8s.io/api/extensions/v1",
 	"metav1":            "k8s.io/apimachinery/pkg/apis/meta/v1",
 	"networkingv1":      "k8s.io/api/networking/v1",
 	"policyv1beta1":     "k8s.io/api/policy/v1beta1",


### PR DESCRIPTION
### Description

This PR consist of the below changes:
Some of the APIs are getting upgrades like kube-system and monitoring bundle helm charts to make it compatible with 1.22.
So, we are migrating the APIs like extensionsv1beta1 to extensionsv1

### Testing
Not required.