### PR TITLE
fix: Use API version client.authentication.k8s.io/v1beta1

### DIFF
--- a/pkg/cluster/kube/kubeconfig.go
+++ b/pkg/cluster/kube/kubeconfig.go
@@ -33,7 +33,7 @@ users:
 - name: {{ .Name }}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - token
       - --region


### PR DESCRIPTION
Generated kubeconfig files now use API version v1beta1 for acquiring
credentials via aws-iam-authenticator. This allows communication with
clusters running newer versions of Kubernetes which no longer support
v1alpha1 (while at the same time eliminating support for clusters
running very old versions).
