### PR TITLE
Revert "fix: Use API version client.authentication.k8s.io/v1beta1"

### DIFF
--- a/pkg/cluster/kube/kubeconfig.go
+++ b/pkg/cluster/kube/kubeconfig.go
@@ -33,7 +33,7 @@ users:
 - name: {{ .Name }}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - token
       - --region


### PR DESCRIPTION
This reverts commit 6f7479a63fe1d412a6fbad5986db4ce641df7970.

In real-world testing, the move up to v1beta1 caused failures, so back
to v1alpha1 we go, for the time being.
