### PR TITLE
build: Pin to golang:1.19.9 for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Fetch or build all required binaries
-FROM golang:1.19 as builder
+FROM golang:1.19.9 as builder
 
 ARG VERSION_REF
 RUN test -n "${VERSION_REF}"


### PR DESCRIPTION
The next version, 1.19.10, is based on Debian 12 (bookworm), which has
a newer glibc version (2.36) than Ubuntu 20.04 (2.31), which our images
are based on. So, a Go executable built on the 1.19.10 image can't run
because glibc in the resulting image is too old.
