### PR TITLE
Fix test data and update lambda Docker run image to use provided.al2

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -25,13 +25,15 @@ RUN make kubeapply-lambda VERSION_REF=${VERSION_REF} && \
     cp build/kubeapply-lambda /usr/local/bin
 
 # Copy into final image
-FROM public.ecr.aws/lambda/go:1
+FROM public.ecr.aws/lambda/provided:al2
 
-RUN yum install -y git && \
-  python3 --version
+RUN yum install -y git unzip
 
-RUN curl -O https://bootstrap.pypa.io/pip/3.6/get-pip.py && python3 get-pip.py
-RUN pip3 install awscli
+# Not sure if awscli is needed for running lambda, but keeping it here for now
+RUN curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip \
+ && unzip awscliv2.zip \
+ && ./aws/install \
+ && rm -rf aws awscliv2.zip
 
 COPY --from=builder \
     /usr/local/bin/aws-iam-authenticator \

--- a/cmd/kubeapply/subcmd/testdata/clusters/expand-test/expanded/stage/us-west-2/kube-system/alb-ingress-controller/templates/alb-ingress-controller.yaml
+++ b/cmd/kubeapply/subcmd/testdata/clusters/expand-test/expanded/stage/us-west-2/kube-system/alb-ingress-controller/templates/alb-ingress-controller.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   labels:
     app: alb-ingress-controller
-  name: alb-ingress-controller-RELEASE-NAME
+  name: alb-ingress-controller-release-name
   namespace: kube-system
 spec:
   replicas: 1

--- a/cmd/kubeapply/subcmd/testdata/clusters/expand-test/expanded/stage/us-west-2/kube-system/alb-ingress-controller2/templates/alb-ingress-controller.yaml
+++ b/cmd/kubeapply/subcmd/testdata/clusters/expand-test/expanded/stage/us-west-2/kube-system/alb-ingress-controller2/templates/alb-ingress-controller.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   labels:
     app: alb-ingress-controller
-  name: alb-ingress-controller-RELEASE-NAME
+  name: alb-ingress-controller-release-name
   namespace: kube-system
 spec:
   replicas: 1

--- a/cmd/kubeapply/subcmd/testdata/clusters/expand-test/expanded_expected/stage/us-west-2/kube-system/alb-ingress-controller/templates/alb-ingress-controller.yaml
+++ b/cmd/kubeapply/subcmd/testdata/clusters/expand-test/expanded_expected/stage/us-west-2/kube-system/alb-ingress-controller/templates/alb-ingress-controller.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   labels:
     app: alb-ingress-controller
-  name: alb-ingress-controller-RELEASE-NAME
+  name: alb-ingress-controller-release-name
   namespace: kube-system
 spec:
   replicas: 1

--- a/cmd/kubeapply/subcmd/testdata/clusters/expand-test/expanded_expected/stage/us-west-2/kube-system/alb-ingress-controller2/templates/alb-ingress-controller.yaml
+++ b/cmd/kubeapply/subcmd/testdata/clusters/expand-test/expanded_expected/stage/us-west-2/kube-system/alb-ingress-controller2/templates/alb-ingress-controller.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 metadata:
   labels:
     app: alb-ingress-controller
-  name: alb-ingress-controller-RELEASE-NAME
+  name: alb-ingress-controller-release-name
   namespace: kube-system
 spec:
   replicas: 1


### PR DESCRIPTION
Per [Migrating AWS Lambda functions from the Go1.x runtime to the custom runtime on Amazon Linux 2](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) this PR changes the Lambda Docker final image from public.ecr.aws/lambda/go:1 to public.ecr.aws/lambda/provided:al2, also changed the `awscli` install from using python3/pip3 to curling the binary