### PR TITLE
Force extremely static builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifndef VERSION_REF
 	VERSION_REF ?= $(shell git describe --tags --always --dirty="-dev")
 endif
 
-LDFLAGS := -ldflags='-s -w -X "main.VersionRef=$(VERSION_REF)"'
+LDFLAGS := -ldflags='-linkmode "external" -extldflags "-static" -s -w -X "main.VersionRef=$(VERSION_REF)"'
 export GOFLAGS := -trimpath
 
 GOFILES = $(shell find . -iname '*.go' | grep -v -e vendor -e _modules -e _cache -e /data/)


### PR DESCRIPTION
kubeapply links against libc, and there's no guarantee that a runtime environment will match what a given binary was built against. This change will ensure that the resulting binary is completely static and able to operate across libc mismatches.